### PR TITLE
Length endpoint + fix

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -9,7 +9,17 @@ import (
 
 func main() {
 	fmt.Println("Sarting...")
-	db.Init("mongodb://localhost:27027", "dico-db", "mots")
+
+	url := "mongodb://localhost:27027"
+	databaseName := "dico-db"
+	collectionName := "mots"
+
+	err := db.Init(url, databaseName, collectionName)
+	if err != nil {
+		fmt.Println("Error while connecting to the database")
+		fmt.Println(err)
+		return
+	}
 
 	r := gin.Default()
 

--- a/api/main.go
+++ b/api/main.go
@@ -14,8 +14,9 @@ func main() {
 	r := gin.Default()
 
 	mot.SetUpRoutes(r)
+	var port = ":4242"
 
-	err := r.Run()
+	err = r.Run(port)
 	if err != nil {
 		fmt.Println("Error while starting the server")
 		panic(err)

--- a/api/mot/Mot.go
+++ b/api/mot/Mot.go
@@ -5,3 +5,7 @@ type Mot struct {
 	Length int `json:"length" bson:"length"`
 	FirstLetter string `json:"first_letter" bson:"first_letter"`
 }
+
+func NewMot(word string) Mot {
+	return Mot{Word: word, Length: len(word), FirstLetter: string(word[0]), SortedLetter: sortLetter(word)}
+}

--- a/api/mot/Mot.go
+++ b/api/mot/Mot.go
@@ -1,11 +1,28 @@
 package mot
 
+import (
+	"fmt"
+	"sort"
+)
+
 type Mot struct {
 	Word string `json:"word" bson:"word"`
 	Length int `json:"length" bson:"length"`
 	FirstLetter string `json:"first_letter" bson:"first_letter"`
+	SortedLetter string `json:"sorted_letter" bson:"sorted_letter"`
 }
 
 func NewMot(word string) Mot {
 	return Mot{Word: word, Length: len(word), FirstLetter: string(word[0]), SortedLetter: sortLetter(word)}
+}
+
+func sortLetter(word string) string {
+	var lettres = []rune(word)
+
+	sort.Slice(lettres, func(i, j int) bool {
+		return lettres[i] < lettres[j]
+	})
+
+	fmt.Printf("Characters: %q\n", lettres)
+	return string(lettres)
 }

--- a/api/mot/MotController.go
+++ b/api/mot/MotController.go
@@ -10,14 +10,14 @@ import (
 )
 
 func SetUpRoutes(c *gin.Engine) {
-	c.GET("/mots/:firstLetter", GetMotsFirsLetter)
-	c.GET("/mot/:firstLetter", GetMotFirsLetter)
+	c.GET("/mots/:firstLetter", getMotsFirstLetter)
+	c.GET("/mot/:firstLetter", getMotFirstLetter)
 	c.GET("/mot/length/:length", getMotLength)
 }
 
 const InvalidFirstLetter = "invalid first letter. Expected one character"
 
-func GetMotsFirsLetter(c *gin.Context) {
+func getMotsFirstLetter(c *gin.Context) {
 	firstLetter := c.Param("firstLetter")
 
 	mots, err := GetMotsFirstLetter(firstLetter)
@@ -36,7 +36,7 @@ func GetMotsFirsLetter(c *gin.Context) {
 
 }
 
-func GetMotFirsLetter(c *gin.Context) {
+func getMotFirstLetter(c *gin.Context) {
 	firstLetter := c.Param("firstLetter")
 
 	mot, err := GetMotFirstLetter(firstLetter)

--- a/api/mot/MotController.go
+++ b/api/mot/MotController.go
@@ -1,56 +1,74 @@
 package mot
 
 import (
+	"errors"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 	"net/http"
-	"unicode/utf8"
+	"strconv"
 )
 
 func SetUpRoutes(c *gin.Engine) {
 	c.GET("/mots/:firstLetter", GetMotsFirsLetter)
 	c.GET("/mot/:firstLetter", GetMotFirsLetter)
+	c.GET("/mot/length/:length", getMotLength)
 }
 
-const InvalidFirstLetter = "Invalid first letter. Expected one character."
+const InvalidFirstLetter = "invalid first letter. Expected one character"
 
-
-func GetMotsFirsLetter( c *gin.Context) {
+func GetMotsFirsLetter(c *gin.Context) {
 	firstLetter := c.Param("firstLetter")
 
-	fmt.Println("firstLetter: ", firstLetter)
-	fmt.Printf("firstLetter: %d\n", utf8.RuneCountInString(firstLetter))
+	mots, err := GetMotsFirstLetter(firstLetter)
 
-	if utf8.RuneCountInString(firstLetter) != 1 {
-		fmt.Println("Invalid first letter")
+	if err != nil {
 		c.JSON(http.StatusBadRequest, getErrorInvalidFirstLetter())
-	} else {
-
-		mots, err := GetMotsFirstLetter(firstLetter)
-
-		if err != nil {
-			c.JSON(http.StatusNotFound, getErrorNoWordStartWith(firstLetter))
-			return
-		}
-
-		c.JSON(http.StatusOK, mots)
+		return
 	}
+
+	if len(mots) == 0 {
+		c.JSON(http.StatusNotFound, getErrorNoWordStartWith(firstLetter))
+		return
+	}
+
+	c.JSON(http.StatusOK, mots)
+
 }
 
-func GetMotFirsLetter( c *gin.Context) {
+func GetMotFirsLetter(c *gin.Context) {
 	firstLetter := c.Param("firstLetter")
 
-	if utf8.RuneCountInString(firstLetter) != 1 {
-		c.JSON(http.StatusBadRequest, getErrorInvalidFirstLetter())
-	} else {
-		mot, err := GetMotFirstLetter(firstLetter)
-		if err != nil {
-			c.JSON(http.StatusNotFound, getErrorNoWordStartWith(firstLetter))
-			return
-		}
+	mot, err := GetMotFirstLetter(firstLetter)
 
-		c.JSON(http.StatusOK, mot)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			c.JSON(http.StatusNotFound, getErrorNoWordStartWith(firstLetter))
+		} else {
+			c.JSON(http.StatusBadRequest, getErrorInvalidFirstLetter())
+		}
+		return
 	}
+
+	c.JSON(http.StatusOK, mot)
+}
+
+func getMotLength(c *gin.Context) {
+	length, err := strconv.Atoi(c.Param("length"))
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, getErrorInvalidLength())
+		return
+	}
+
+	mot, err := GetMotLength(length)
+
+	if err != nil {
+		c.JSON(http.StatusNotFound, getErrorNoWordWithLength(length))
+		return
+	}
+
+	c.JSON(http.StatusOK, mot)
 }
 
 func getErrorNoWordStartWith(firstLetter string) gin.H {
@@ -59,4 +77,12 @@ func getErrorNoWordStartWith(firstLetter string) gin.H {
 
 func getErrorInvalidFirstLetter() gin.H {
 	return gin.H{"error": InvalidFirstLetter}
+}
+
+func getErrorNoWordWithLength(length int) gin.H {
+	return gin.H{"error": fmt.Sprintf("No words with length (%d)", length)}
+}
+
+func getErrorInvalidLength() gin.H {
+	return gin.H{"error": "Please give a number"}
 }

--- a/api/mot/MotService.go
+++ b/api/mot/MotService.go
@@ -54,7 +54,3 @@ func GetMotFirstLetter(firstLetter string) (Mot, error) {
 
 	return resultat, err
 }
-
-func NewMot(word string) Mot {
-	return Mot{Word: word, Length: len(word), FirstLetter: string(word[0])}
-}

--- a/api/mot/MotService.go
+++ b/api/mot/MotService.go
@@ -3,12 +3,18 @@ package mot
 import (
 	"Dico/db"
 	"context"
+	"errors"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"time"
+	"unicode/utf8"
 )
 
 func GetMotsFirstLetter(firstLetter string) ([]Mot, error) {
+	if utf8.RuneCountInString(firstLetter) != 1 {
+		return nil, errors.New(InvalidFirstLetter)
+	}
+
 	var mots []Mot
 	collection := db.GetCollection()
 
@@ -18,20 +24,15 @@ func GetMotsFirstLetter(firstLetter string) ([]Mot, error) {
 	cursor, _ := collection.Find(ctx, bson.D{{"first_letter", firstLetter}})
 	_ = cursor.All(context.TODO(), &mots)
 
-	var err error
-	var resultat []Mot
-
-	if len(mots) == 0 {
-		err = mongo.ErrNoDocuments
-	} else {
-		resultat = mots
-	}
-
-	return resultat, err
+	return mots, nil
 }
 
 
 func GetMotFirstLetter(firstLetter string) (Mot, error) {
+	if utf8.RuneCountInString(firstLetter) != 1 {
+		return NewMot("nil"), errors.New(InvalidFirstLetter)
+	}
+
 	var mots []Mot
 	collection := db.GetCollection()
 
@@ -39,6 +40,30 @@ func GetMotFirstLetter(firstLetter string) (Mot, error) {
 	defer cancel()
 
 	matchStage := bson.D{{"$match", bson.D{{"first_letter", firstLetter}}}}
+	sampleStage := bson.D{{"$sample", bson.D{{"size", 1}}}}
+	cursor, _ := collection.Aggregate(ctx, mongo.Pipeline{matchStage, sampleStage})
+	_ = cursor.All(context.TODO(), &mots)
+
+	var err error
+	var resultat Mot
+
+	if len(mots) == 0 {
+		err = mongo.ErrNoDocuments
+	} else {
+		resultat = mots[0]
+	}
+
+	return resultat, err
+}
+
+func GetMotLength(length int) (Mot, error) {
+	var mots []Mot
+	collection := db.GetCollection()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	matchStage := bson.D{{"$match", bson.D{{"length", length}}}}
 	sampleStage := bson.D{{"$sample", bson.D{{"size", 1}}}}
 	cursor, _ := collection.Aggregate(ctx, mongo.Pipeline{matchStage, sampleStage})
 	_ = cursor.All(context.TODO(), &mots)

--- a/api/mot/Mot_test.go
+++ b/api/mot/Mot_test.go
@@ -1,0 +1,32 @@
+package mot
+
+import "testing"
+
+func Test_sort(t *testing.T) {
+	type args struct {
+		mot string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test sortLetter with niche",
+			args: args{mot: "niche"},
+			want: "cehin",
+		},
+		{
+			name: "Test sortLetter with chien",
+			args: args{mot: "chien"},
+			want: "cehin",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sortLetter(tt.args.mot); got != tt.want {
+				t.Errorf("sortLetter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/populate/populate.go
+++ b/api/populate/populate.go
@@ -13,8 +13,6 @@ import (
 	"unicode"
 )
 
-// Fonctions de nettoyage et validation identiques au précédent exemple
-
 func main() {
 	// Contexte avec timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
@@ -32,12 +30,13 @@ func main() {
 	}
 	defer file.Close()
 
-	// Scanner le fichier ligne par ligne
 	scanner := bufio.NewScanner(file)
+
 	compteur := 0
 	batchSize := 1000
 	var wordsBatch []interface{}
 
+	// Parcourir le fichier ligne par ligne
 	for scanner.Scan() {
 		motTexte := cleanWord(scanner.Text())
 
@@ -63,6 +62,17 @@ func main() {
 			}
 		}
 	}
+	// Insérer les mots restants
+	if len(wordsBatch) > 0 {
+		_, err := collection.InsertMany(ctx, wordsBatch)
+		if err != nil {
+			fmt.Sprintf("erreur lors de l'insertion du batch : %v", err)
+			return
+		}
+
+		compteur += len(wordsBatch)
+		fmt.Printf("Processed %d words\n", compteur)
+	}
 
 	if err := scanner.Err(); err != nil {
 		log.Fatal(err)
@@ -81,6 +91,7 @@ func cleanWord(word string) string {
 func isValidWord(word string) bool {
 	for _, r := range word {
 		if !unicode.IsLetter(r) {
+			fmt.Printf("Le mot %s n'est pas valide\n", word)
 			return false
 		}
 	}


### PR DESCRIPTION
This pull request includes several improvements and new features to the `api` package, specifically focusing on database initialization, route handling, and word processing. The most important changes include enhancing error handling during database initialization, adding new routes and associated logic, and improving word processing functionality.

### Database Initialization and Error Handling:
* [`api/main.go`](diffhunk://#diff-dbbf781c8730222f6af11a8481f93399b3332deb43edca36865a02b64647afd1L12-R29): Enhanced error handling during database initialization and added a specific port for server startup.

### Route Handling:
* [`api/mot/MotController.go`](diffhunk://#diff-329ff3fd86f149f3cc8b82006330151f7ebf5245327a5560f159c2c2eb89cb32R4-R71): Added new route `getMotLength` and improved error handling for existing routes.
* [`api/mot/MotController.go`](diffhunk://#diff-329ff3fd86f149f3cc8b82006330151f7ebf5245327a5560f159c2c2eb89cb32R81-R88): Added new error handling functions for invalid length and no words found with specified length.

### Word Processing:
* [`api/mot/Mot.go`](diffhunk://#diff-72326f435dc1ee95c5ee2b10064042c0607bfab2488e7b0034faf1c11497a04aR3-R27): Introduced new fields and methods in the `Mot` struct for sorting letters and creating new `Mot` instances.
* [`api/mot/MotService.go`](diffhunk://#diff-acb80146fafdf7564d33ab1275233f795fecd4b0aac53644e94f06a80e809ef6R6-R95): Added validation for first letter and new service methods for fetching words by length.
* [`api/mot/Mot_test.go`](diffhunk://#diff-b40ebe00bbf3929750814690752571b11fae3f1284384bb60a65c69db66f2833R1-R32): Added unit tests for the `sortLetter` function to ensure correct sorting of letters in words.

### Miscellaneous:
* [`api/populate/populate.go`](diffhunk://#diff-061609369d6ff2c510a0a7c4a247988fcb0907b14abe7bf201f34cf9179d633eL16-L17): Improved comments and added logic to handle the insertion of remaining words after batch processing. [[1]](diffhunk://#diff-061609369d6ff2c510a0a7c4a247988fcb0907b14abe7bf201f34cf9179d633eL16-L17) [[2]](diffhunk://#diff-061609369d6ff2c510a0a7c4a247988fcb0907b14abe7bf201f34cf9179d633eL35-R39) [[3]](diffhunk://#diff-061609369d6ff2c510a0a7c4a247988fcb0907b14abe7bf201f34cf9179d633eR65-R75) [[4]](diffhunk://#diff-061609369d6ff2c510a0a7c4a247988fcb0907b14abe7bf201f34cf9179d633eR94)